### PR TITLE
Fix README for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Arguments in localized strings has to be in format `%1$s`, e.g `Message from %1$
 ## iOS Setup
 Ensure that your .strings files are placed under language-specific .lproj folders (e.g., en.lproj, cs.lproj).
 
-Arguments in localized strings has to be in format `%1$s`, e.g `Message from %@ to %@.`
+Arguments in localized strings has to be in format `%1$@`, e.g `Message from %1$@ to %2$@.`
 
 ## 👏 Contributing
 


### PR DESCRIPTION
Hi! 

I just tried your plugin and think it's super handy! Exactly what I needed! Thank you very much for make it available! 

I noticed a small mistake in the iOS documentation in the Readme.

It should now match with the regex in native_fcm_strings.dart file.